### PR TITLE
/users ordered by number of presentations given

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def index
     # very inefficient but not a problem considering the low volume of data
-    @users = User.includes(:presentations).order(:name).load
+    @users = User.joins(:presentations).group('users.id').order("count(users.id) DESC")
   end
 
   def show

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,17 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+if Rails.env.development? || Rails.env.test?
+  AdminUser.create(email: 'admin@pinoyrb.org', password: 'pinoyrborg')
+
+  # Creates Ruby users, presentations and events where the presentations were held.
+  (1..10).each do |n|
+    user = User.create!(name: "Ruby User #{n}", email: "user_#{n}@pinoyrb.org", password: 'pinoyrborg')
+    n.times do |presentation_count|
+      event = Event.find_or_create_by!(name: "Event #{presentation_count}", event_type: 'meetup')
+      presentation = Presentation.create!(name: "Presentation #{presentation_count}", event: event)
+      Speaker.create!(presentation: presentation, user: user)
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -7,6 +7,23 @@ describe UsersController do
       get 'index'
       expect(response).to be_success
     end
+
+    it "orders users by descending number of presentations given" do
+      (1..10).each do |n|
+        user = create(:user, name: "Ruby User #{n}", email: "user_#{n}@pinoyrb.org")
+        # create n presentations for n-th user
+        n.times do |presentation_count|
+          event = create(:event)
+          presentation = create(:presentation, event: event)
+          speaker = create(:speaker, presentation: presentation, user: user)
+        end
+      end
+
+      get 'index'
+
+      presentation_counts = assigns(:users).map { |u| u.presentations.count }
+      expect(presentation_counts).to eq((1..10).to_a.reverse)
+    end
   end
 
   describe "GET 'show'" do

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :event do
     event_type "meetup"
-    name "MyString"
+    sequence(:name) {|n| "Event #{n}" }
     description "MyText"
     venue
     start_at "2013-03-31 15:44:46"

--- a/spec/factories/presentations.rb
+++ b/spec/factories/presentations.rb
@@ -2,8 +2,7 @@
 
 FactoryGirl.define do
   factory :presentation do
-    name "MyString"
-    slug "MyString"
+    sequence(:name) {|n| "Presentation #{n}" }
     description "MyText"
     event nil
     youtube "MyString"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@ Spork.prefork do
   Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
   RSpec.configure do |config|
+    config.include FactoryGirl::Syntax::Methods
+
     # ## Mock Framework
     #
     # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
... to encourage more speakers to present in the monthly meetups.

Why I think this is important:

1. The https://pinoyrb.org/users page is part of what has driven me to start speaking up in meetups. Countless talks haven been given by me since then, good and bad.
2. Making the list of contributors in http://contributors.rubyonrails.org/ is part of what helped others to start contributing to the repo. I reckon that if we include this as part of our call for speakers in the next (and final) meetup of the year, we'll encourage more people to volunteer as speakers.