### PR TITLE
Don't bundle `libnotify` gem on systems that don't support it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :test do
   gem 'launchy'
   gem 'simplecov', :require => false
   gem 'growl'
-  gem 'libnotify'
+  gem 'libnotify' if /linux/ =~ RUBY_PLATFORM
   gem 'rb-inotify', :require => false
   gem 'rb-fsevent', :require => false
   gem 'shoulda-matchers'


### PR DESCRIPTION
(e.g. macOS)

Getting the following warnings

    Could not open library 'libgtk-x11-2.0': dlopen(libgtk-x11-2.0, 13): image not found.
    Could not open library 'libgtk-x11-2.0.dylib': dlopen(libgtk-x11-2.0.dylib, 13): image not found.
    Could not open library 'libgtk-x11-2.0.so.0': dlopen(libgtk-x11-2.0.so.0, 13): image not found.
    Could not open library 'libgtk-x11-2.0.so.0.dylib': dlopen(libgtk-x11-2.0.so.0.dylib, 13): image not found.
    Could not open library 'libgtk-x11-2.0.so': dlopen(libgtk-x11-2.0.so, 13): image not found.
    Could not open library 'libgtk-x11-2.0.so.dylib': dlopen(libgtk-x11-2.0.so.dylib, 13): image not found.
    Could not open library 'libgtk-3': dlopen(libgtk-3, 13): image not found.
    Could not open library 'libgtk-3.dylib': dlopen(libgtk-3.dylib, 13): image not found.
    Could not open library 'libgtk-3.so.0': dlopen(libgtk-3.so.0, 13): image not found.
    Could not open library 'libgtk-3.so.0.dylib': dlopen(libgtk-3.so.0.dylib, 13): image not found.
    Could not open library 'libgtk-3.so': dlopen(libgtk-3.so, 13): image not found.
    Could not open library 'libgtk-3.so.dylib': dlopen(libgtk-3.so.dylib, 13): image not found